### PR TITLE
Use application config variable instead of Mix.env

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -21,6 +21,8 @@ use Mix.Config
 #     config :logger, level: :info
 #
 
+config :gendex, spawn_parser: Mix.env != :test
+
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment
 # by uncommenting the line below and defining dev.exs, test.exs and such.

--- a/lib/gendex.ex
+++ b/lib/gendex.ex
@@ -27,10 +27,10 @@ defmodule Gendex do
   def start(_type, _args) do
     Entries.start_link
 
-    if Mix.env == :test do
-      Parser.parse
-    else
+    if Application.get_env(:gendex, :spawn_parser) do
       spawn(Parser, :parse, [])
+    else
+      Parser.parse
     end
 
     {:ok, self}


### PR DESCRIPTION
Hey there! First of all, thank you very much for your work on this library. 

I was wondering if you'd consider using an application config variable to determine if the parser should be spawned instead of relying on `Mix.env` given that `Mix` is not available when running in a release. I took the liberty of creating a PR to do this, feel free to discard it or let me know if you'd like anything done differently.

:)